### PR TITLE
Add Terraform template for code-server deployment

### DIFF
--- a/terraform/.gitignore
+++ b/terraform/.gitignore
@@ -1,0 +1,50 @@
+# Local .terraform directories
+**/.terraform/*
+
+# .tfstate files
+*.tfstate
+*.tfstate.*
+
+# Crash log files
+crash.log
+crash.*.log
+
+# Exclude all .tfvars files, which are likely to contain sensitive data, such as
+# password, private keys, and other secrets. These should not be part of version 
+# control as they are data points which are potentially sensitive and subject 
+# to change depending on the environment.
+*.tfvars
+*.tfvars.json
+
+# Ignore override files as they are usually used to override resources locally and so
+# are not checked in
+override.tf
+override.tf.json
+*_override.tf
+*_override.tf.json
+
+# Include override files you do wish to add to version control using negated pattern
+# !example_override.tf
+
+# Include tfplan files to ignore the plan output of command: terraform plan -out=tfplan
+# example: *tfplan*
+
+# Ignore CLI configuration files
+.terraformrc
+terraform.rc
+
+# Ignore Mac system files
+.DS_Store
+
+# Ignore editor files
+*.swp
+*.swo
+*~
+
+# Ignore test cache
+.terraform.lock.hcl
+
+# Keep example files
+!terraform.tfvars.example
+!*.tf
+!*.md

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -1,0 +1,228 @@
+# Code-Server Terraform Template
+
+This Terraform template deploys a code-server instance on AWS EC2 with CloudFront distribution and automatic password storage in AWS Systems Manager Parameter Store.
+
+## Architecture
+
+The template creates:
+- EC2 instance running Ubuntu 22.04 LTS with code-server
+- Security Group allowing CloudFront access on port 8080
+- CloudFront distribution for global access
+- Elastic IP for static public IP
+- IAM role with SSM permissions
+- SSM Parameter Store for secure password storage
+
+## Supported Regions
+
+- `us-west-2` (default)
+- `us-east-1`
+- `ap-southeast-1`
+
+## Prerequisites
+
+- [Terraform](https://www.terraform.io/downloads.html) >= 1.0
+- [AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html) configured with appropriate permissions
+- AWS credentials configured (via AWS CLI, environment variables, or IAM roles)
+
+## Required AWS Permissions
+
+Your AWS credentials need the following permissions:
+- EC2: Create/manage instances, security groups, elastic IPs
+- IAM: Create/manage roles and instance profiles
+- CloudFront: Create/manage distributions and cache policies
+- SSM: Create/read parameters
+- VPC: Describe VPCs and subnets (if using default VPC)
+
+## Quick Start
+
+1. **Clone and navigate to the terraform directory:**
+   ```bash
+   git clone <repository-url>
+   cd terraform/
+   ```
+
+2. **Copy and customize the example variables:**
+   ```bash
+   cp terraform.tfvars.example terraform.tfvars
+   # Edit terraform.tfvars with your preferred settings
+   ```
+
+3. **Initialize and apply Terraform:**
+   ```bash
+   terraform init
+   terraform plan
+   terraform apply
+   ```
+
+4. **Retrieve the code-server password:**
+   ```bash
+   # Get just the password value
+   aws ssm get-parameter --name "/code-server/password" --with-decryption --region <your-region> --query 'Parameter.Value' --output text
+   
+   # Or get full parameter details
+   aws ssm get-parameter --name "/code-server/password" --with-decryption --region <your-region>
+   
+   # Using the terraform output command
+   $(terraform output -raw password_retrieval_command)
+   ```
+
+5. **Access code-server:**
+   - Get the CloudFront URL from terraform output: `terraform output vscode_server_cloudfront_domain_name`
+   - Open the URL in your browser
+   - Enter the password retrieved from SSM
+
+## Configuration
+
+### Variables
+
+| Variable | Description | Default | Required |
+|----------|-------------|---------|----------|
+| `aws_region` | AWS region to deploy resources | `us-west-2` | No |
+| `vscode_server_version` | Version of code-server to install | `4.91.1` | No |
+| `instance_type` | EC2 instance type | `t2.xlarge` | No |
+| `vpc_id` | VPC ID (uses default VPC if empty) | `""` | No |
+| `subnet_id` | Subnet ID (uses default subnet if empty) | `""` | No |
+| `internet_cidr_block` | CIDR block for internet access | `0.0.0.0/0` | No |
+| `origin_request_policy_id` | CloudFront origin request policy ID | `216adef6-5c7f-47e4-b989-5492eafa07d3` | No |
+| `common_tags` | Common tags for all resources | `{Project = "code-server"}` | No |
+
+### Example terraform.tfvars
+
+```hcl
+aws_region            = "us-west-2"
+vscode_server_version = "4.91.1"
+instance_type         = "t2.xlarge"
+
+# Optional: Use existing VPC/subnet
+# vpc_id    = "vpc-12345678"
+# subnet_id = "subnet-12345678"
+
+common_tags = {
+  Project     = "code-server"
+  Environment = "dev"
+  Owner       = "your-name"
+}
+```
+
+## Outputs
+
+| Output | Description |
+|--------|-------------|
+| `vscode_server_cloudfront_domain_name` | CloudFront URL for accessing code-server |
+| `vscode_server_public_ip` | Public IP address of the instance |
+| `vscode_server_private_ip` | Private IP address of the instance |
+| `vscode_server_instance_id` | EC2 instance ID |
+| `vscode_server_role_arn` | IAM role ARN |
+| `vscode_server_password_ssm` | SSM parameter path for password |
+| `password_retrieval_command` | AWS CLI command to get password |
+
+## Code-Server Configuration
+
+The code-server is configured to:
+- Listen on `0.0.0.0:8080` (accessible via CloudFront)
+- Use password authentication (stored in SSM)
+- Include the Amazon Q extension pre-installed
+- Run as a systemd service under the `ubuntu` user
+
+You can modify the configuration by connecting to the instance:
+```bash
+# Connect via SSM Session Manager
+aws ssm start-session --target <instance-id> --region <region>
+
+# Edit configuration
+sudo nano /home/ubuntu/.config/code-server/config.yaml
+
+# Restart service
+sudo systemctl restart code-server@ubuntu
+```
+
+## Access Methods
+
+### Option 1: CloudFront (Recommended)
+Access via the CloudFront distribution URL (from terraform output). This provides:
+- Global edge locations for better performance
+- HTTPS termination
+- DDoS protection
+
+### Option 2: Direct IP Access
+Access directly via the public IP on port 8080 (HTTP only).
+
+### Option 3: SSM Port Forwarding
+Forward the code-server port to your local machine:
+```bash
+aws ssm start-session \
+  --target <instance-id> \
+  --document-name AWS-StartPortForwardingSessionToRemoteHost \
+  --parameters '{"portNumber":["8080"],"localPortNumber":["8080"],"host":["<private-ip>"]}' \
+  --region <region>
+```
+
+## Security Considerations
+
+- The security group only allows access from CloudFront IP ranges
+- Password is stored encrypted in SSM Parameter Store
+- Instance uses IAM roles (no hardcoded credentials)
+- All traffic to CloudFront is over HTTPS
+- Consider restricting `internet_cidr_block` for additional security
+
+## Troubleshooting
+
+### Check instance status:
+```bash
+# Get instance ID from terraform output
+terraform output vscode_server_instance_id
+
+# Check instance status
+aws ec2 describe-instances --instance-ids <instance-id> --region <region>
+```
+
+### Check UserData script execution:
+```bash
+# Connect to instance
+aws ssm start-session --target <instance-id> --region <region>
+
+# Check cloud-init logs
+sudo cat /var/log/cloud-init-output.log | grep "INFO:"
+
+# Check code-server service
+sudo systemctl status code-server@ubuntu
+```
+
+### Verify SSM parameter:
+```bash
+aws ssm get-parameter --name "/code-server/password" --region <region>
+```
+
+## Testing
+
+Basic Terratest is included in the `test/` directory:
+
+```bash
+cd test/
+go mod init terraform-test
+go mod tidy
+go test -v -timeout 30m
+```
+
+## Cleanup
+
+To destroy all resources:
+```bash
+terraform destroy
+```
+
+## Differences from CloudFormation Template
+
+This Terraform template provides the same functionality as the CloudFormation version with these improvements:
+- Dynamic AMI lookup (always uses latest Ubuntu 22.04 LTS)
+- Dynamic CloudFront prefix list lookup (works in any supported region)
+- Additional output with password retrieval command
+- Terraform validation for region constraints
+- Modular file structure for better maintainability
+
+## Support
+
+For issues or questions:
+1. Check the troubleshooting section above
+2. Review AWS CloudWatch logs for the EC2 instance
+3. Verify your AWS permissions and region support

--- a/terraform/data.tf
+++ b/terraform/data.tf
@@ -1,0 +1,55 @@
+# Get default VPC if vpc_id is not specified
+data "aws_vpc" "default" {
+  count   = var.vpc_id == "" ? 1 : 0
+  default = true
+}
+
+# Get specified VPC if vpc_id is provided
+data "aws_vpc" "selected" {
+  count = var.vpc_id != "" ? 1 : 0
+  id    = var.vpc_id
+}
+
+# Get default subnet if subnet_id is not specified
+data "aws_subnets" "default" {
+  count = var.subnet_id == "" ? 1 : 0
+  filter {
+    name   = "vpc-id"
+    values = [local.vpc_id]
+  }
+  filter {
+    name   = "default-for-az"
+    values = ["true"]
+  }
+}
+
+# Get latest Ubuntu 22.04 LTS AMI
+data "aws_ami" "ubuntu" {
+  most_recent = true
+  owners      = ["099720109477"] # Canonical
+
+  filter {
+    name   = "name"
+    values = ["ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-*"]
+  }
+
+  filter {
+    name   = "virtualization-type"
+    values = ["hvm"]
+  }
+}
+
+# Get CloudFront managed prefix list for the region
+data "aws_ec2_managed_prefix_list" "cloudfront" {
+  name = "com.amazonaws.global.cloudfront.origin-facing"
+}
+
+# Get current AWS account ID and region
+data "aws_caller_identity" "current" {}
+data "aws_region" "current" {}
+
+# Local values for computed resources
+locals {
+  vpc_id    = var.vpc_id != "" ? var.vpc_id : data.aws_vpc.default[0].id
+  subnet_id = var.subnet_id != "" ? var.subnet_id : data.aws_subnets.default[0].ids[0]
+}

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,0 +1,207 @@
+# Security Group for VSCode Server
+resource "aws_security_group" "vscode_server_security_group" {
+  name_prefix = "vscode-server-sg-"
+  description = "Allow ingress from CloudFront prefix list"
+  vpc_id      = local.vpc_id
+
+  tags = merge(var.common_tags, {
+    Name = "VSCodeServer-SecurityGroup"
+  })
+}
+
+# Security Group Ingress Rule
+resource "aws_security_group_rule" "vscode_server_security_group_ingress" {
+  type              = "ingress"
+  description       = "Open port 8080 for the CloudFront prefix list"
+  from_port         = 8080
+  to_port           = 8080
+  protocol          = "tcp"
+  prefix_list_ids   = [data.aws_ec2_managed_prefix_list.cloudfront.id]
+  security_group_id = aws_security_group.vscode_server_security_group.id
+}
+
+# Security Group Egress Rule
+resource "aws_security_group_rule" "vscode_server_security_group_egress" {
+  type              = "egress"
+  description       = "Egress for vscode security group"
+  from_port         = 0
+  to_port           = 0
+  protocol          = "-1"
+  cidr_blocks       = [var.internet_cidr_block]
+  security_group_id = aws_security_group.vscode_server_security_group.id
+}
+
+# IAM Role for VSCode Server
+resource "aws_iam_role" "vscode_server_iam_role" {
+  name_prefix = "VSCodeServer-Role-"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = "sts:AssumeRole"
+        Effect = "Allow"
+        Principal = {
+          Service = "ec2.amazonaws.com"
+        }
+      }
+    ]
+  })
+
+  managed_policy_arns = [
+    "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
+  ]
+
+  inline_policy {
+    name = "SSMParameterAccess"
+    policy = jsonencode({
+      Version = "2012-10-17"
+      Statement = [
+        {
+          Effect = "Allow"
+          Action = [
+            "ssm:PutParameter",
+            "ssm:GetParameter"
+          ]
+          Resource = "arn:aws:ssm:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:parameter/code-server/*"
+        }
+      ]
+    })
+  }
+
+  tags = var.common_tags
+}
+
+# Instance Profile
+resource "aws_iam_instance_profile" "instance_profile" {
+  name_prefix = "VSCodeServer-InstanceProfile-"
+  role        = aws_iam_role.vscode_server_iam_role.name
+
+  tags = var.common_tags
+}
+
+# Elastic IP
+resource "aws_eip" "vscode_server_eip" {
+  domain = "vpc"
+
+  tags = merge(var.common_tags, {
+    Name = "VSCodeServer-EIP"
+  })
+}
+
+# User Data Script
+locals {
+  user_data = base64encode(templatefile("${path.module}/user_data.sh", {
+    version = var.vscode_server_version
+    region  = data.aws_region.current.name
+  }))
+}
+
+# EC2 Instance
+resource "aws_instance" "vscode_server" {
+  ami                     = data.aws_ami.ubuntu.id
+  instance_type           = var.instance_type
+  subnet_id               = local.subnet_id
+  vpc_security_group_ids  = [aws_security_group.vscode_server_security_group.id]
+  iam_instance_profile    = aws_iam_instance_profile.instance_profile.name
+  user_data_base64        = local.user_data
+  monitoring              = true
+
+  tags = merge(var.common_tags, {
+    Name = "VSCodeServer"
+  })
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+# Associate Elastic IP
+resource "aws_eip_association" "vscode_server_eip_association" {
+  instance_id   = aws_instance.vscode_server.id
+  allocation_id = aws_eip.vscode_server_eip.id
+}
+
+# CloudFront Cache Policy
+resource "aws_cloudfront_cache_policy" "vscode_server_cloudfront_cache_policy" {
+  name        = "VSCodeServer-${random_id.cache_policy_suffix.hex}"
+  comment     = "Cache policy for VSCode Server"
+  default_ttl = 86400
+  max_ttl     = 31536000
+  min_ttl     = 1
+
+  parameters_in_cache_key_and_forwarded_to_origin {
+    enable_accept_encoding_gzip = false
+
+    cookies_config {
+      cookie_behavior = "all"
+    }
+
+    headers_config {
+      header_behavior = "whitelist"
+      headers {
+        items = [
+          "Accept-Charset",
+          "Authorization", 
+          "Origin",
+          "Accept",
+          "Referer",
+          "Host",
+          "Accept-Language",
+          "Accept-Encoding",
+          "Accept-Datetime"
+        ]
+      }
+    }
+
+    query_strings_config {
+      query_string_behavior = "all"
+    }
+  }
+}
+
+# Random ID for cache policy name uniqueness
+resource "random_id" "cache_policy_suffix" {
+  byte_length = 4
+}
+
+# CloudFront Distribution
+resource "aws_cloudfront_distribution" "vscode_server_cloudfront" {
+  origin {
+    domain_name = aws_eip.vscode_server_eip.public_dns
+    origin_id   = "VS-code-server"
+
+    custom_origin_config {
+      http_port              = 8080
+      https_port             = 443
+      origin_protocol_policy = "http-only"
+      origin_ssl_protocols   = ["TLSv1.2"]
+    }
+  }
+
+  enabled = true
+
+  default_cache_behavior {
+    allowed_methods            = ["DELETE", "GET", "HEAD", "OPTIONS", "PATCH", "POST", "PUT"]
+    cached_methods             = ["GET", "HEAD"]
+    target_origin_id           = "VS-code-server"
+    compress                   = false
+    viewer_protocol_policy     = "allow-all"
+    cache_policy_id            = aws_cloudfront_cache_policy.vscode_server_cloudfront_cache_policy.id
+    origin_request_policy_id   = var.origin_request_policy_id
+  }
+
+  restrictions {
+    geo_restriction {
+      restriction_type = "none"
+    }
+  }
+
+  viewer_certificate {
+    cloudfront_default_certificate = true
+  }
+
+  tags = var.common_tags
+
+  depends_on = [aws_eip_association.vscode_server_eip_association]
+}

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -1,0 +1,34 @@
+output "vscode_server_cloudfront_domain_name" {
+  description = "CloudFront distribution domain name for accessing code-server"
+  value       = "https://${aws_cloudfront_distribution.vscode_server_cloudfront.domain_name}"
+}
+
+output "vscode_server_public_ip" {
+  description = "Public IP address of the code-server instance"
+  value       = aws_eip.vscode_server_eip.public_ip
+}
+
+output "vscode_server_private_ip" {
+  description = "Private IP address of the code-server instance"
+  value       = aws_instance.vscode_server.private_ip
+}
+
+output "vscode_server_instance_id" {
+  description = "Instance ID of the code-server EC2 instance"
+  value       = aws_instance.vscode_server.id
+}
+
+output "vscode_server_role_arn" {
+  description = "ARN of the IAM role attached to the code-server instance"
+  value       = aws_iam_role.vscode_server_iam_role.arn
+}
+
+output "vscode_server_password_ssm" {
+  description = "SSM Parameter path containing the code-server password"
+  value       = "/code-server/password"
+}
+
+output "password_retrieval_command" {
+  description = "AWS CLI command to retrieve the code-server password"
+  value       = "aws ssm get-parameter --name '/code-server/password' --with-decryption --region ${data.aws_region.current.name}"
+}

--- a/terraform/terraform.tfvars.example
+++ b/terraform/terraform.tfvars.example
@@ -1,0 +1,27 @@
+# AWS Region (must be one of: us-west-2, us-east-1, ap-southeast-1)
+aws_region = "us-west-2"
+
+# Code-server version to install
+vscode_server_version = "4.91.1"
+
+# EC2 instance type
+instance_type = "t2.xlarge"
+
+# Optional: Specify existing VPC ID (leave empty to use default VPC)
+# vpc_id = "vpc-12345678"
+
+# Optional: Specify existing subnet ID (leave empty to use default subnet)
+# subnet_id = "subnet-12345678"
+
+# CIDR block for internet access
+internet_cidr_block = "0.0.0.0/0"
+
+# CloudFront origin request policy ID
+origin_request_policy_id = "216adef6-5c7f-47e4-b989-5492eafa07d3"
+
+# Common tags to apply to all resources
+common_tags = {
+  Project     = "code-server"
+  Environment = "dev"
+  Owner       = "your-name"
+}

--- a/terraform/test/terraform_test.go
+++ b/terraform/test/terraform_test.go
@@ -1,0 +1,60 @@
+package test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/gruntwork-io/terratest/modules/aws"
+	"github.com/gruntwork-io/terratest/modules/terraform"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTerraformCodeServer(t *testing.T) {
+	t.Parallel()
+
+	// Pick a random AWS region to test in
+	awsRegion := "us-west-2"
+
+	terraformOptions := terraform.WithDefaultRetryableErrors(t, &terraform.Options{
+		// The path to where our Terraform code is located
+		TerraformDir: "../",
+
+		// Variables to pass to our Terraform code using -var options
+		Vars: map[string]interface{}{
+			"aws_region": awsRegion,
+		},
+
+		// Environment variables to set when running Terraform
+		EnvVars: map[string]string{
+			"AWS_DEFAULT_REGION": awsRegion,
+		},
+	})
+
+	// At the end of the test, run `terraform destroy` to clean up any resources that were created
+	defer terraform.Destroy(t, terraformOptions)
+
+	// This will run `terraform init` and `terraform apply` and fail the test if there are any errors
+	terraform.InitAndApply(t, terraformOptions)
+
+	// Run `terraform output` to get the value of an output variable
+	instanceId := terraform.Output(t, terraformOptions, "vscode_server_instance_id")
+	publicIp := terraform.Output(t, terraformOptions, "vscode_server_public_ip")
+	cloudfrontUrl := terraform.Output(t, terraformOptions, "vscode_server_cloudfront_domain_name")
+	ssmParameter := terraform.Output(t, terraformOptions, "vscode_server_password_ssm")
+
+	// Verify the outputs are not empty
+	assert.NotEmpty(t, instanceId)
+	assert.NotEmpty(t, publicIp)
+	assert.NotEmpty(t, cloudfrontUrl)
+	assert.Equal(t, "/code-server/password", ssmParameter)
+
+	// Verify the EC2 instance is running
+	aws.GetInstancesByTag(t, awsRegion, "Name", "VSCodeServer")
+
+	// Wait for the instance to be ready (UserData script to complete)
+	time.Sleep(5 * time.Minute)
+
+	// Verify SSM parameter exists
+	parameterValue := aws.GetParameter(t, awsRegion, "/code-server/password")
+	assert.NotEmpty(t, parameterValue)
+}

--- a/terraform/user_data.sh
+++ b/terraform/user_data.sh
@@ -1,17 +1,10 @@
 #!/bin/bash
 echo "INFO: Starting UserData script execution"
 
-# Wait for automatic apt updates to complete
-echo "INFO: Waiting for automatic apt updates to complete"
-while sudo fuser /var/lib/dpkg/lock-frontend >/dev/null 2>&1; do
-  echo "INFO: Waiting for apt lock to be released..."
-  sleep 10
-done
-
 # Install AWS CLI
 echo "INFO: Installing AWS CLI prerequisites"
-apt-get update
-DEBIAN_FRONTEND=noninteractive apt-get install -y curl unzip
+apt-get -o DPkg::Lock::Timeout=-1 update
+DEBIAN_FRONTEND=noninteractive apt-get -o DPkg::Lock::Timeout=-1 install -y curl unzip
 echo "INFO: Prerequisites installed, downloading AWS CLI"
 curl -fsSL https://awscli.amazonaws.com/awscli-exe-linux-$(uname -m).zip -o /tmp/aws-cli.zip
 echo "INFO: Extracting AWS CLI"

--- a/terraform/user_data.sh
+++ b/terraform/user_data.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+echo "INFO: Starting UserData script execution"
+
+# Wait for automatic apt updates to complete
+echo "INFO: Waiting for automatic apt updates to complete"
+while sudo fuser /var/lib/dpkg/lock-frontend >/dev/null 2>&1; do
+  echo "INFO: Waiting for apt lock to be released..."
+  sleep 10
+done
+
+# Install AWS CLI
+echo "INFO: Installing AWS CLI prerequisites"
+apt-get update
+DEBIAN_FRONTEND=noninteractive apt-get install -y curl unzip
+echo "INFO: Prerequisites installed, downloading AWS CLI"
+curl -fsSL https://awscli.amazonaws.com/awscli-exe-linux-$(uname -m).zip -o /tmp/aws-cli.zip
+echo "INFO: Extracting AWS CLI"
+unzip -q -d /tmp /tmp/aws-cli.zip
+echo "INFO: Installing AWS CLI"
+sudo /tmp/aws/install
+rm -rf /tmp/aws /tmp/aws-cli.zip
+echo "INFO: AWS CLI installation complete"
+aws --version
+
+# Install code-server
+echo "INFO: Installing code-server"
+curl -fOL https://github.com/coder/code-server/releases/download/v${version}/code-server_${version}_amd64.deb
+sudo dpkg -i code-server_${version}_amd64.deb
+echo "INFO: Enabling and starting code-server"
+sudo systemctl enable --now code-server@ubuntu
+sleep 30
+
+# Configure password
+echo "INFO: Configuring code-server"
+# sed -i.bak 's/auth: password/auth: none/' /home/ubuntu/.config/code-server/config.yaml
+# Expose code server service 
+sed -i.bak 's/bind-addr: 127.0.0.1:8080/bind-addr: 0.0.0.0:8080/' /home/ubuntu/.config/code-server/config.yaml
+
+# Restart code server
+echo "INFO: Restarting code-server"
+sudo systemctl restart code-server@ubuntu
+
+# Install extension amazonwebservices.amazon-q-vscode
+echo "INFO: Installing Amazon Q extension"
+sudo -u ubuntu code-server --install-extension amazonwebservices.amazon-q-vscode
+
+# Restart code server
+echo "INFO: Final restart of code-server"
+sudo systemctl restart code-server@ubuntu
+
+# Store password in SSM Parameter Store for easy retrieval
+echo "INFO: Storing password in SSM Parameter Store"
+sleep 10  # Wait for config file to be fully written
+CODE_SERVER_PASSWORD=$(sudo grep "^password:" /home/ubuntu/.config/code-server/config.yaml | cut -d' ' -f2)
+echo "INFO: Extracted password, creating SSM parameter"
+aws ssm put-parameter \
+  --name "/code-server/password" \
+  --value "$CODE_SERVER_PASSWORD" \
+  --type "SecureString" \
+  --region ${region} \
+  --overwrite
+echo "INFO: SSM parameter creation complete"
+echo "INFO: UserData script execution finished"

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,0 +1,58 @@
+variable "aws_region" {
+  description = "AWS region to deploy resources"
+  type        = string
+  default     = "us-west-2"
+
+  validation {
+    condition = contains([
+      "us-west-2",
+      "us-east-1", 
+      "ap-southeast-1"
+    ], var.aws_region)
+    error_message = "Region must be one of: us-west-2, us-east-1, ap-southeast-1."
+  }
+}
+
+variable "vscode_server_version" {
+  description = "Version of code-server to install"
+  type        = string
+  default     = "4.91.1"
+}
+
+variable "internet_cidr_block" {
+  description = "CIDR block for internet access"
+  type        = string
+  default     = "0.0.0.0/0"
+}
+
+variable "vpc_id" {
+  description = "VPC ID to deploy resources (optional, uses default VPC if not specified)"
+  type        = string
+  default     = ""
+}
+
+variable "subnet_id" {
+  description = "Subnet ID to deploy EC2 instance (optional, uses default subnet if not specified)"
+  type        = string
+  default     = ""
+}
+
+variable "instance_type" {
+  description = "EC2 instance type for code-server"
+  type        = string
+  default     = "t2.xlarge"
+}
+
+variable "origin_request_policy_id" {
+  description = "CloudFront origin request policy ID"
+  type        = string
+  default     = "216adef6-5c7f-47e4-b989-5492eafa07d3"
+}
+
+variable "common_tags" {
+  description = "Common tags to apply to all resources"
+  type        = map(string)
+  default = {
+    Project = "code-server"
+  }
+}

--- a/terraform/versions.tf
+++ b/terraform/versions.tf
@@ -1,0 +1,18 @@
+terraform {
+  required_version = ">= 1.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.1"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.aws_region
+}


### PR DESCRIPTION
# Add Terraform Template for Code-Server Deployment

## Summary
Adds a Terraform template as an alternative to the existing CloudFormation template, providing users with both IaC options for deploying code-server on AWS.

## Features
- Terraform implementation with modular structure
- Feature parity with CloudFormation template
- Dynamic resource lookups (AMI, CloudFront prefix lists)
- SSM parameter storage for secure password management
- Region flexibility - works in any supported region without hardcoded mappings
- Basic Terratest included

## Architecture
Creates identical infrastructure to CloudFormation:
- EC2 instance with code-server
- CloudFront distribution for global access
- Security group (CloudFront access only)
- Elastic IP and IAM role with SSM permissions
- Encrypted password storage in SSM Parameter Store

## Usage
```bash
cd terraform/
cp terraform.tfvars.example terraform.tfvars
terraform init && terraform apply
aws ssm get-parameter --name "/code-server/password" --with-decryption --region <region>
```

## Testing
- Successfully deployed and tested in `us-east-1`
- Verified CloudFront access and SSM parameter creation
- Confirmed security model and code-server functionality

## Files Added
```
terraform/
├── *.tf files (main, variables, outputs, data, versions)
├── user_data.sh, README.md, .gitignore
├── terraform.tfvars.example
└── test/terraform_test.go
```